### PR TITLE
papertrail出力用に、標準出力と標準出力エラーを吐き出す。

### DIFF
--- a/web/DB_config.php
+++ b/web/DB_config.php
@@ -5,15 +5,15 @@ DB情報を取得する。
 ****/
 
 //heroku上の環境変数からpostgresの接続パラメータを取得
-
+/*
 $url = parse_url(getenv('DATABASE_URL'));
 $param = "host=".$url['host']." port=".$url['port']." dbname=".substr($url['path'], 1)." user=".$url['user']." password=".$url['pass'];
 define("DEF_CONNECT_PARAM",$param);
-
+*/
 
 //local環境でのpostgresの接続パラメータを取得
-/*
+
 $param = "host=localhost port=5432 dbname=db_test01 user=postgres password=g1o3o5d7";
 define("DEF_CONNECT_PARAM", $param);
-*/
+
 ?>

--- a/web/index.php
+++ b/web/index.php
@@ -4,6 +4,10 @@ require('../vendor/autoload.php');
 
 include('./DB_config.php');
 
+$stdout= fopen( 'php://stdout', 'w' );
+$stderr= fopen('php://stderr','w');
+
+fwrite( $stdout, "index.php access next DB-connect\n" );
 //$url = parse_url(getenv('DATABASE_URL'));
 /*
 $dsn = sprintf('pgsql:host=%s;dbname=%s', $url['host'], substr($url['path'], 1));
@@ -31,6 +35,7 @@ echo("host=".$url['host']." port=".$url['port']." dbname=".substr($url['path'], 
 $conn = pg_connect(DEF_CONNECT_PARAM);
 if (!$conn) {
     die('接続できませんでした');
+    fwrite( $stdout, "Not DB Connect\n" );
 }
 
 //ランダムに出力するための、テーブルサイズ取得


### PR DESCRIPTION
DB接続エラーを起こすために、DB情報をローカル情報にする
